### PR TITLE
Remove franchise references

### DIFF
--- a/pdf_text_extract_1.py
+++ b/pdf_text_extract_1.py
@@ -53,7 +53,7 @@ def is_section_heading(text, next_line):
     # Example: If it's fully capitalized, assume it's a heading
     if text.isupper():
         return True
-    # Detect common FDD section patterns like "ITEM 1: OVERVIEW"
+    # Detect common document section patterns like "ITEM 1: OVERVIEW"
     if re.match(r"^ITEM \d+[:\s]", text, re.IGNORECASE):
         return True
     # If the next line is empty or a separator, treat it as a heading

--- a/setup_text_db.py
+++ b/setup_text_db.py
@@ -1,7 +1,7 @@
 import sqlite3
 import os
 
-#Create text chunk database to store text chunks from FDDs once they are converted to text document.  
+# Create text chunk database to store text chunks extracted from recipe PDFs.
 
 # Database path
 DB_PATH = "recipe_text_chunks.db"

--- a/split_recipe_text_2.py
+++ b/split_recipe_text_2.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 import tiktoken
 
-#Step 2: Splitting the FDD Text into Chunks
+# Step 2: Splitting the recipe text into chunks
 
 # Configurations
 DB_PATH = "recipe_text_chunks.db"
@@ -45,8 +45,8 @@ def store_chunks_in_db(filename, chunks):
     conn.close()
     print(f"✅ Stored {len(chunks)} text chunks from {filename} in the database.")
 
-def process_fdd_text():
-    """Reads all cleaned FDD text files, splits them into chunks, and stores them in the database."""
+def process_recipe_text():
+    """Reads all cleaned recipe text files, splits them into chunks, and stores them in the database."""
     if not os.path.exists(INPUT_FOLDER):
         print(f"🚨 Error: `{INPUT_FOLDER}` folder not found. Ensure text files exist.")
         return
@@ -67,4 +67,4 @@ def process_fdd_text():
         print(f"✅ Processed and stored chunks from {file}.")
 
 if __name__ == "__main__":
-    process_fdd_text()
+    process_recipe_text()

--- a/templates/index.html
+++ b/templates/index.html
@@ -156,7 +156,7 @@
 <body>
     <div id="main-wrapper">
         <div class="loading-wrapper">
-            <div id="loading-message">Checking Franchise list for updates... please wait.</div>
+            <div id="loading-message">Checking recipe list for updates... please wait.</div>
         </div>
         <div id="chat-container">
             <div id="chat-box"></div>


### PR DESCRIPTION
## Summary
- replace franchise text in the web template
- rename `process_franchise_names.py` to `process_recipe_names.py`
- adjust helper scripts to use recipe terminology
- rename `split_fdd_text_2.py` to `split_recipe_text_2.py`
- clean up minor comments

## Testing
- `python -m py_compile $(git ls-files '*.py')`